### PR TITLE
Pass on predefined type to useSelect filter

### DIFF
--- a/src/hooks/data/use-select.ts
+++ b/src/hooks/data/use-select.ts
@@ -29,7 +29,7 @@ export type UseSelectConfig<Data = any> = {
 
 export function useSelect<Data = any>(
     table: string,
-    config: UseSelectConfig = { columns: '*', options: {} },
+    config: UseSelectConfig<Data> = { columns: '*', options: {} },
 ): UseSelectResponse<Data> {
     const client = useClient()
     const isMounted = useRef(false)


### PR DESCRIPTION
The type `Profile` is not passed down to the `filter` function, so it's not aware of the properties of the actual record


```tsx
  const { data, error } = useSelect<Profile>('profiles', {
    filter: (query) => query.eq('id', user.id).single(),
  })
```

```
(property) filter?: false | Filter<any>
Type '(query: PostgrestFilterBuilder<any>) => PromiseLike<PostgrestSingleResponse<any>>' is not assignable to type 'false | Filter<any>'.
  Type '(query: PostgrestFilterBuilder<any>) => PromiseLike<PostgrestSingleResponse<any>>' is not assignable to type 'Filter<any>'.
    Type 'PromiseLike<PostgrestSingleResponse<any>>' is missing the following properties from type 'PostgrestFilterBuilder<any>': not, or, eq, neq, and 39 more.ts(2322)
use-select.d.ts(18, 5): The expected type comes from property 'filter' which is declared here on type 'UseSelectConfig<any>'
```

I've reviewed the other hooks in the folder for the same kind of problem, but they were okay.